### PR TITLE
Incorporate eid3205

### DIFF
--- a/draft-spaghetti-sidrops-rpki-crl-numbers.xml
+++ b/draft-spaghetti-sidrops-rpki-crl-numbers.xml
@@ -153,7 +153,7 @@ version="3">
           <t>NEW</t>
           <blockquote>
             <t>
-              An RPKI CA MUST include the two extensions, Authority Key Identifier (AKI) and CRL Number, in every CRL that it issues.
+              An RPKI CA MUST include exactly two extensions in every CRL that it issues: an Authority Key Identifier (AKI) and a CRL Number.
               No other CRL extensions are allowed.
               RPs MUST be prepared to process the AKI extension, and MUST ignore the CRL Number.
             </t>


### PR DESCRIPTION
This rephrases the text to disallow repeated extensions by specifying exactly which extensions must be present. This avoids repeating the text from RFC 5280 and seems both clearer and more explicit.

https://www.rfc-editor.org/errata/eid3205

Closes: #3