### PR TITLE
List Routinator as a compliant implementation

### DIFF
--- a/draft-spaghetti-sidrops-rpki-crl-numbers.xml
+++ b/draft-spaghetti-sidrops-rpki-crl-numbers.xml
@@ -214,6 +214,14 @@ version="3">
           </front>
         </reference>
 
+	<reference anchor="routinator" target="https://github.com/NLnetLabs/routinator">
+          <front>
+            <title>Routinator</title>
+            <author fullname="NLnetLabs"/>
+            <date/>
+          </front>
+        </reference>
+
       </references>
     </references>
 
@@ -243,6 +251,9 @@ version="3">
         <li>
           <xref target="FORT"/>
         </li>
+	<li>
+	  <xref target="routinator"/> additionally checks that the CRL Number is non-negative and fits into 20 octets.
+	</li>
       </ul>
     </section>
 


### PR DESCRIPTION
The rpki crate parses the CRL number, checks that it is present, non-critical and also checks that it is a well-formed non-negative integer, but it otherwise ignores it.

@partim do you agree with this reading?